### PR TITLE
Rename method validate to validateParams

### DIFF
--- a/src/Traits/JsonRpcController.php
+++ b/src/Traits/JsonRpcController.php
@@ -46,7 +46,7 @@ trait JsonRpcController
      * @return bool|MessageBag Прошла валидация или нет
      * @throws InvalidParametersException
      */
-    protected function validate($rules, array $messages = [], $noException = false)
+    protected function validateParams($rules, array $messages = [], $noException = false)
     {
         return $this->validateData($this->getArrayRequest(), $rules, $messages, $noException);
     }


### PR DESCRIPTION
Fix for:
`Fatal error: Access level to Nbz4live\JsonRpc\Server\Traits\JsonRpcController::validate() must be public (as in class Laravel\Lumen\Routing\Controller)`