### PR TITLE
Fixed incompatible DocBlock/Types/Object_.php

### DIFF
--- a/src/DocBlock/Types/Object_.php
+++ b/src/DocBlock/Types/Object_.php
@@ -33,7 +33,7 @@ class Object_ implements Type
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->className) {
             return (string)$this->className;


### PR DESCRIPTION
Fatal error: Declaration of Nbz4live\JsonRpc\Server\DocBlock\Types\Object_::__toString() must be compatible with phpDocumentor\Reflection\Type::__toString(): string in /projects/minigames-service/vendor/nbz4live/laravel-jsonrpc-server/src/DocBlock/Types/Object_.php on line 11